### PR TITLE
Added props clusterPrecisePointCount and clusterPointLimit

### DIFF
--- a/MapView/CustomMarker.js
+++ b/MapView/CustomMarker.js
@@ -45,27 +45,27 @@ export default class CustomMarker extends Component {
         let markerWidth, markerHeight, textSize;
         let point_count = this.state.point_count;
 
-        if(point_count>=2 && point_count<=10){
+        if(point_count>=2 && (GLOBAL.clusterPrecisePointCount || point_count<=10)){
             textForCluster = point_count.toString();
             markerWidth = width*2/15;
             markerHeight = width*2/15;
             textSize = height/40;
-        }if(point_count>10&&point_count<=25){
+        }else if(point_count>10&&point_count<=25){
             textForCluster = '10+';
             markerWidth = width/7;
             markerHeight = width/7;
             textSize = height/40;
-        }if(point_count>25&&point_count<=50){
+        }else if(point_count>25&&point_count<=50){
             textForCluster = '25+';
             markerWidth = width*2/13;
             markerHeight = width*2/13;
             textSize = height/40;
-        }if(point_count>50&&point_count<=100){
+        }else if(point_count>50&&point_count<=100){
             textForCluster = '50+';
             markerWidth = width/6;
             markerHeight = width/6;
             textSize = height/38;
-        }if(point_count>100){
+        }else if(point_count>100){
             textForCluster = '100+';
             markerWidth = width*2/11;
             markerHeight = width*2/11;
@@ -106,7 +106,7 @@ export default class CustomMarker extends Component {
                         {...this.state.props}
                         coordinate = {coordinates}
                         onPress = {()=>{
-                            let markers = superCluster.getLeaves(this.state.clusterId);
+                            let markers = superCluster.getLeaves(this.state.clusterId, GLOBAL.clusterPointLimit);
                             this.props.onClusterPress(this.state.coordinates, markers);
                         }}>
                         {htmlElement}

--- a/MapView/MapWithClustering.js
+++ b/MapView/MapWithClustering.js
@@ -159,6 +159,8 @@ export default class MapWithClustering extends Component {
         GLOBAL.clusterBorderColor = this.props.clusterBorderColor;
         GLOBAL.clusterBorderWidth = this.props.clusterBorderWidth;
         GLOBAL.clusterTextSize = this.props.clusterTextSize;
+        GLOBAL.clusterPrecisePointCount = this.props.clusterPrecisePointCount;
+        GLOBAL.clusterPointLimit = this.props.clusterPointLimit;
 
         return (
             <MapView {...this.props}
@@ -182,6 +184,8 @@ MapWithClustering.defaultProps = {
     clusterBorderColor: '#FF5252',
     clusterBorderWidth: 1,
     clusterTextSize: null,
+    clusterPrecisePointCount: false,
+    clusterPointLimit: 10,
     clustering: true,
     maxZoom: 10,
     radius: 40

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ All you have to do is to add 'cluster' prop to marker like this:
 | clusterTextColor   | String | #FF5252 | Color of text in cluster.                                      |
 | clusterBorderColor | String | #FF5252 | Color of border. Set to transparent if you don't want borders. |
 | clusterBorderWidth | Int    | 1       | Width of border. Set to 0 if you don't want borders.           |
-| clusterTextSize | Int    | 18       | Text size for clusters.           |
+| clusterTextSize    | Int    | 18      | Text size for clusters.                                        |
+| clusterPointLimit  | Int    | 10      | Limit the number of points shown in the cluster                |
+| clusterPrecisePointCount | bool   | false   | Set true to give precise point count at cluster, else gives rought ranges e.g. "10+", "25+" |
 | onClusterPress | Function    | null       | Allows you to control cluster on click event.  Function returns coordinate of cluster.         |
 | customClusterMarkerDesign | HTML element    | null       | Custom background for your clusters.           |
 | maxZoom | Int    | 10       | Maximum zoom level at which clusters are generated.           |
@@ -175,6 +177,8 @@ Example of using props:
     clusterTextColor = '#fff'
     clusterBorderColor = '#fff'
     clusterBorderWidth = {4}
+    clusterPrecisePointCount = {true}
+    clusterPointLimit = Infinity
     maxZoom = {8}
     radius = {50}
     initialRegion={{latitude: 52.5, longitude: 19.2,


### PR DESCRIPTION
1. clusterPrecisePointCount: true to give precise point count at cluster, else gives rough ranges e.g. "10+", "25+"
2. clusterPointLimit: value to limit the number of points to display at the cluster